### PR TITLE
feat: Kubernetes Support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Version control
+.git
+.gitignore
+
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.pyo
+.venv/
+*.egg-info/
+dist/
+build/
+
+# Environment files (never bake secrets into the image)
+.env
+.env.*
+!.env.example
+
+# Development tooling
+.ruff_cache/
+.mypy_cache/
+.pytest_cache/
+.coverage
+htmlcov/
+
+# Docker
+Dockerfile
+.dockerignore
+docker-compose*.yml
+
+# Helm
+helm/
+
+# Documentation
+README.md
+CONTRIBUTING.md
+*.md
+
+# Clients and examples
+mcp_client/
+
+# CI / release tooling
+.github/
+Makefile
+cliff.toml

--- a/.dockerignore
+++ b/.dockerignore
@@ -31,10 +31,10 @@ docker-compose*.yml
 # Helm
 helm/
 
-# Documentation
-README.md
+# Documentation (README.md is needed by hatchling to build the package)
 CONTRIBUTING.md
 *.md
+!README.md
 
 # Clients and examples
 mcp_client/

--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,8 @@
+remote: origin
+target-branch: main
+chart-dirs:
+  - helm
+check-version-increment: true
+ignored-path-prefixes:
+  - helm/elasticsearch-mcp-server/README.md
+  - helm/elasticsearch-mcp-server/tests/

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,36 @@
+name: Publish Docker image to GHCR
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract release tag
+        id: extract_tag
+        run: echo "RELEASE_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/cr7258/elasticsearch-mcp-server:${{ env.RELEASE_TAG }}

--- a/.github/workflows/helm-chart.yaml
+++ b/.github/workflows/helm-chart.yaml
@@ -73,4 +73,4 @@ jobs:
         run: helm package helm/elasticsearch-mcp-server
 
       - name: Push chart to OCI registry
-        run: helm push elasticsearch-mcp-server-*.tgz oci://ghcr.io/charts/cr7258
+        run: helm push elasticsearch-mcp-server-*.tgz oci://ghcr.io/cr7258/charts

--- a/.github/workflows/helm-chart.yaml
+++ b/.github/workflows/helm-chart.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: helm/chart-testing-action@v2
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.3.2 --verify=false
 
       - name: Detect changed charts
         id: list-changed

--- a/.github/workflows/helm-chart.yaml
+++ b/.github/workflows/helm-chart.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: helm/chart-testing-action@v2
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false
 
       - name: Detect changed charts
         id: list-changed

--- a/.github/workflows/helm-chart.yaml
+++ b/.github/workflows/helm-chart.yaml
@@ -1,0 +1,76 @@
+name: Helm Chart
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "helm/**"
+  push:
+    branches: ["main"]
+    paths:
+      - "helm/**"
+      - "!helm/**/README.md"
+      - "!helm/**/tests/**"
+
+jobs:
+  lint-test:
+    name: Lint and Test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # required by ct to compare against target branch
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest
+
+      - name: Detect changed charts
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --config .github/ct.yaml --target-branch "${{ github.event.repository.default_branch }}")
+          echo "changed=$changed" >> "$GITHUB_OUTPUT"
+
+      - name: Lint changed charts
+        if: steps.list-changed.outputs.changed != ''
+        run: ct lint --config .github/ct.yaml --target-branch "${{ github.event.repository.default_branch }}"
+
+      - name: Run unit tests
+        if: steps.list-changed.outputs.changed != ''
+        run: helm unittest helm/elasticsearch-mcp-server
+
+  publish:
+    name: Publish to OCI Registry
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: lint-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Package chart
+        run: helm package helm/elasticsearch-mcp-server
+
+      - name: Push chart to OCI registry
+        run: helm push elasticsearch-mcp-server-*.tgz oci://ghcr.io/charts/cr7258

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,8 +50,5 @@ USER appuser
 
 EXPOSE 8000
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz', timeout=5)"
-
 ENTRYPOINT ["/app/entrypoint.sh"]
 CMD ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 # Copy source and install the project itself
 COPY src/ /app/src/
-COPY pyproject.toml /app/
+COPY pyproject.toml uv.lock LICENSE README.md /app/
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev
+    uv sync --frozen --no-dev --no-editable
 
 # ---------------------------------------------------------------------------
 # Runtime: minimal image without uv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1
+
+# ---------------------------------------------------------------------------
+# Builder: install dependencies into a virtual environment using uv
+# ---------------------------------------------------------------------------
+FROM ghcr.io/astral-sh/uv:python3.10-bookworm-slim AS builder
+
+WORKDIR /app
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
+
+# Install dependencies first to leverage layer caching
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --no-dev --no-install-project
+
+# Copy source and install the project itself
+COPY src/ /app/src/
+COPY pyproject.toml /app/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev
+
+# ---------------------------------------------------------------------------
+# Runtime: minimal image without uv
+# ---------------------------------------------------------------------------
+FROM python:3.10-slim-bookworm
+
+WORKDIR /app
+
+RUN groupadd -r appuser && useradd --no-log-init -r -g appuser -u 1000 appuser
+
+# Copy the pre-built virtual environment and source
+COPY --from=builder --chown=appuser:appuser /app/.venv /app/.venv
+COPY --from=builder --chown=appuser:appuser /app/src /app/src
+
+# Copy and configure entrypoint
+COPY --chown=appuser:appuser docker/entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    # Default: disable SSL verification for self-signed certs (override in production)
+    VERIFY_CERTS=false
+
+USER appuser
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/healthz', timeout=5)"
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["--transport", "streamable-http", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -358,7 +358,7 @@ uv run src/server.py elasticsearch-mcp-server
 
 ## Kubernetes Deployment
 
-The Docker image is published to `ghcr.io/cr7258/elasticsearch-mcp-server` and the Helm chart is available as an OCI artifact at `oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server` which is available in `oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server` repository.
+The Docker image is published to `ghcr.io/cr7258/elasticsearch-mcp-server` and the Helm chart is available as an OCI artifact at `oci://ghcr.io/cr7258/charts/elasticsearch-mcp-server` repository.
 
 For full installation instructions, configuration reference, and usage examples see the **[Helm chart README](helm/elasticsearch-mcp-server/README.md)**.
 

--- a/README.md
+++ b/README.md
@@ -356,6 +356,12 @@ If you want to run different Elasticsearch variants (e.g., 7.x or 9.x) locally, 
 uv run src/server.py elasticsearch-mcp-server
 ```
 
+## Kubernetes Deployment
+
+The Docker image is published to `ghcr.io/cr7258/elasticsearch-mcp-server` and the Helm chart is available as an OCI artifact at `oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server` which is available in `oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server` repository.
+
+For full installation instructions, configuration reference, and usage examples see the **[Helm chart README](helm/elasticsearch-mcp-server/README.md)**.
+
 ## License
 
 This project is licensed under the Apache License Version 2.0 - see the [LICENSE](LICENSE) file for details.

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+# Select the MCP server entry point based on ENGINE_TYPE env var.
+# Defaults to elasticsearch if not set.
+ENGINE_TYPE="${ENGINE_TYPE:-elasticsearch}"
+
+if [ "$ENGINE_TYPE" = "opensearch" ]; then
+    exec opensearch-mcp-server "$@"
+else
+    exec elasticsearch-mcp-server "$@"
+fi

--- a/helm/elasticsearch-mcp-server/Chart.yaml
+++ b/helm/elasticsearch-mcp-server/Chart.yaml
@@ -1,0 +1,15 @@
+apiVersion: v2
+name: elasticsearch-mcp-server
+description: MCP Server for interacting with Elasticsearch and OpenSearch clusters
+type: application
+version: 0.1.0
+appVersion: "2.0.19"
+keywords:
+  - elasticsearch
+  - opensearch
+  - mcp
+  - ai
+  - llm
+home: https://github.com/elastic/elasticsearch-mcp-server
+maintainers:
+  - name: elasticsearch-mcp-server

--- a/helm/elasticsearch-mcp-server/Chart.yaml
+++ b/helm/elasticsearch-mcp-server/Chart.yaml
@@ -10,6 +10,6 @@ keywords:
   - mcp
   - ai
   - llm
-home: https://github.com/elastic/elasticsearch-mcp-server
+home: https://github.com/cr7258/elasticsearch-mcp-server
 maintainers:
   - name: elasticsearch-mcp-server

--- a/helm/elasticsearch-mcp-server/Chart.yaml
+++ b/helm/elasticsearch-mcp-server/Chart.yaml
@@ -12,4 +12,5 @@ keywords:
   - llm
 home: https://github.com/cr7258/elasticsearch-mcp-server
 maintainers:
-  - name: elasticsearch-mcp-server
+  - name: treezio
+    url: https://github.com/treezio

--- a/helm/elasticsearch-mcp-server/README.md
+++ b/helm/elasticsearch-mcp-server/README.md
@@ -1,0 +1,152 @@
+# elasticsearch-mcp-server Helm Chart
+
+Helm chart for deploying the [Elasticsearch/OpenSearch MCP Server](https://github.com/cr7258/elasticsearch-mcp-server) on Kubernetes.
+
+## Prerequisites
+
+- Kubernetes 1.23+
+- Helm 3.10+
+- A running Elasticsearch or OpenSearch cluster reachable from within the cluster
+
+## Docker image
+
+The Docker image is published to the GitHub Container Registry:
+
+```
+ghcr.io/cr7258/elasticsearch-mcp-server:<version>
+```
+
+The image runs as a non-root user with a read-only root filesystem and exposes the MCP server on port `8000` using `streamable-http` transport by default.
+
+## Install the chart
+
+The Helm chart is published as an OCI artifact to the GitHub Container Registry:
+
+```
+oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server
+```
+
+**Elasticsearch — username/password:**
+
+```bash
+helm install elasticsearch-mcp oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server \
+  --set elasticsearch.hosts="https://your-elasticsearch:9200" \
+  --set auth.credentials.elasticsearchUsername=elastic \
+  --set auth.credentials.elasticsearchPassword=changeme \
+  --set auth.credentials.mcpApiKey=your-secure-mcp-token
+```
+
+**Elasticsearch — API key (recommended):**
+
+```bash
+helm install elasticsearch-mcp oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server \
+  --set elasticsearch.hosts="https://your-elasticsearch:9200" \
+  --set auth.credentials.elasticsearchApiKey=your-api-key \
+  --set auth.credentials.mcpApiKey=your-secure-mcp-token
+```
+
+**OpenSearch:**
+
+```bash
+helm install opensearch-mcp oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server \
+  --set server.engineType=opensearch \
+  --set opensearch.hosts="https://your-opensearch:9200" \
+  --set auth.credentials.opensearchUsername=admin \
+  --set auth.credentials.opensearchPassword=changeme \
+  --set auth.credentials.mcpApiKey=your-secure-mcp-token
+```
+
+## Secret management
+
+The chart supports two strategies for managing credentials.
+
+**Option A — chart-managed Secret** (suitable for development):
+
+Set values under `auth.credentials.*`. The chart creates a Kubernetes `Secret` and mounts the values as environment variables.
+
+```yaml
+auth:
+  credentials:
+    elasticsearchUsername: elastic
+    elasticsearchPassword: changeme
+    elasticsearchApiKey: ""       # takes precedence over password when set
+    mcpApiKey: your-mcp-token
+```
+
+**Option B — existing Secret** (recommended for production, e.g. with External Secrets Operator):
+
+```yaml
+auth:
+  existingSecret: my-secret-name
+  existingSecretKeys:
+    elasticsearchUsername: elasticsearch-username
+    elasticsearchPassword: elasticsearch-password
+    elasticsearchApiKey: elasticsearch-api-key
+    opensearchUsername: opensearch-username
+    opensearchPassword: opensearch-password
+    mcpApiKey: mcp-api-key
+```
+
+When `auth.existingSecret` is set, no Secret is created by the chart.
+
+## Key configuration values
+
+| Parameter | Description | Default |
+|---|---|---|
+| `image.repository` | Docker image repository | `ghcr.io/cr7258/elasticsearch-mcp-server` |
+| `image.tag` | Image tag (defaults to chart `appVersion`) | `""` |
+| `server.engineType` | `elasticsearch` or `opensearch` | `elasticsearch` |
+| `server.transport` | `streamable-http` or `sse` (`stdio` is not supported in Kubernetes) | `streamable-http` |
+| `server.port` | Port the MCP server listens on | `8000` |
+| `elasticsearch.hosts` | Elasticsearch host URL | `https://elasticsearch:9200` |
+| `elasticsearch.verifyCerts` | Verify TLS certificates | `false` |
+| `opensearch.hosts` | OpenSearch host URL | `https://opensearch:9200` |
+| `opensearch.verifyCerts` | Verify TLS certificates | `false` |
+| `auth.credentials.elasticsearchUsername` | ES basic auth username | `""` |
+| `auth.credentials.elasticsearchPassword` | ES basic auth password | `""` |
+| `auth.credentials.elasticsearchApiKey` | ES API key (takes precedence over password) | `""` |
+| `auth.credentials.opensearchUsername` | OpenSearch basic auth username | `""` |
+| `auth.credentials.opensearchPassword` | OpenSearch basic auth password | `""` |
+| `auth.credentials.mcpApiKey` | Bearer token for MCP server authentication | `""` |
+| `auth.existingSecret` | Use a pre-existing Secret instead of creating one | `""` |
+| `risk.disableHighRiskOperations` | Disable all write/delete operations | `false` |
+| `risk.disabledOperations` | Comma-separated list of specific operations to disable | `""` |
+| `ingress.enabled` | Expose the MCP server via an Ingress | `false` |
+| `autoscaling.enabled` | Enable Horizontal Pod Autoscaler | `false` |
+
+For the full list of configurable values see [values.yaml](values.yaml).
+
+## Health endpoints
+
+The server exposes two HTTP endpoints used as Kubernetes probes:
+
+| Endpoint | Probe | Success | Failure |
+|---|---|---|---|
+| `GET /healthz` | Liveness — is the process alive? | `200 {"status":"ok"}` | — |
+| `GET /readyz` | Readiness — is the search cluster reachable? | `200 {"status":"ok","search_engine":"..."}` | `503` |
+
+The chart configures these automatically via `livenessProbe` and `readinessProbe` in `values.yaml`.
+
+## Verify the deployment
+
+```bash
+# Port-forward the service
+kubectl port-forward svc/elasticsearch-mcp 8000:8000
+
+# Liveness
+curl http://localhost:8000/healthz
+# {"status":"ok"}
+
+# Readiness (returns 503 until the search cluster is reachable)
+curl http://localhost:8000/readyz
+# {"status":"ok","search_engine":"elasticsearch"}
+```
+
+## Running the unit tests
+
+The chart ships with a [helm-unittest](https://github.com/helm-unittest/helm-unittest) test suite:
+
+```bash
+helm plugin install https://github.com/helm-unittest/helm-unittest
+helm unittest helm/elasticsearch-mcp-server/
+```

--- a/helm/elasticsearch-mcp-server/README.md
+++ b/helm/elasticsearch-mcp-server/README.md
@@ -23,13 +23,13 @@ The image runs as a non-root user with a read-only root filesystem and exposes t
 The Helm chart is published as an OCI artifact to the GitHub Container Registry:
 
 ```
-oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server
+oci://ghcr.io/cr7258/charts/elasticsearch-mcp-server
 ```
 
 **Elasticsearch — username/password:**
 
 ```bash
-helm install elasticsearch-mcp oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server \
+helm install elasticsearch-mcp oci://ghcr.io/cr7258/charts/elasticsearch-mcp-server \
   --set elasticsearch.hosts="https://your-elasticsearch:9200" \
   --set auth.credentials.elasticsearchUsername=elastic \
   --set auth.credentials.elasticsearchPassword=changeme \
@@ -39,7 +39,7 @@ helm install elasticsearch-mcp oci://ghcr.io/charts/cr7258/elasticsearch-mcp-ser
 **Elasticsearch — API key (recommended):**
 
 ```bash
-helm install elasticsearch-mcp oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server \
+helm install elasticsearch-mcp oci://ghcr.io/cr7258/charts/elasticsearch-mcp-server \
   --set elasticsearch.hosts="https://your-elasticsearch:9200" \
   --set auth.credentials.elasticsearchApiKey=your-api-key \
   --set auth.credentials.mcpApiKey=your-secure-mcp-token
@@ -48,7 +48,7 @@ helm install elasticsearch-mcp oci://ghcr.io/charts/cr7258/elasticsearch-mcp-ser
 **OpenSearch:**
 
 ```bash
-helm install opensearch-mcp oci://ghcr.io/charts/cr7258/elasticsearch-mcp-server \
+helm install opensearch-mcp oci://ghcr.io/cr7258/charts/elasticsearch-mcp-server \
   --set server.engineType=opensearch \
   --set opensearch.hosts="https://your-opensearch:9200" \
   --set auth.credentials.opensearchUsername=admin \

--- a/helm/elasticsearch-mcp-server/templates/NOTES.txt
+++ b/helm/elasticsearch-mcp-server/templates/NOTES.txt
@@ -1,0 +1,41 @@
+Elasticsearch MCP Server {{ .Chart.AppVersion }} deployed successfully.
+
+Engine:    {{ .Values.server.engineType }}
+Transport: {{ .Values.server.transport }}
+MCP path:  {{ include "elasticsearch-mcp-server.serverPath" . }}
+
+{{- if .Values.ingress.enabled }}
+
+MCP endpoint:
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ include "elasticsearch-mcp-server.serverPath" $ }}
+{{- end }}
+
+{{- else if contains "NodePort" .Values.service.type }}
+
+MCP endpoint (NodePort):
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "elasticsearch-mcp-server.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "http://$NODE_IP:$NODE_PORT{{ include "elasticsearch-mcp-server.serverPath" . }}"
+
+{{- else if contains "LoadBalancer" .Values.service.type }}
+
+MCP endpoint (LoadBalancer — may take a few minutes to become available):
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "elasticsearch-mcp-server.fullname" . }} --template "{{ "{{ range (index .status.loadBalancer.ingress 0) }}{{ . }}{{ end }}" }}")
+  echo "http://$SERVICE_IP:{{ .Values.service.port }}{{ include "elasticsearch-mcp-server.serverPath" . }}"
+
+{{- else }}
+
+MCP endpoint (port-forward):
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "elasticsearch-mcp-server.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  echo "MCP server: http://127.0.0.1:{{ .Values.service.port }}{{ include "elasticsearch-mcp-server.serverPath" . }}"
+
+{{- end }}
+
+{{- if not .Values.auth.credentials.mcpApiKey }}
+{{- if not .Values.auth.existingSecret }}
+
+⚠️  WARNING: MCP_API_KEY is not set. The MCP server is accessible WITHOUT authentication.
+   Set auth.credentials.mcpApiKey or reference an existing secret via auth.existingSecret.
+{{- end }}
+{{- end }}

--- a/helm/elasticsearch-mcp-server/templates/_helpers.tpl
+++ b/helm/elasticsearch-mcp-server/templates/_helpers.tpl
@@ -1,0 +1,87 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "elasticsearch-mcp-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "elasticsearch-mcp-server.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart label value.
+*/}}
+{{- define "elasticsearch-mcp-server.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "elasticsearch-mcp-server.labels" -}}
+helm.sh/chart: {{ include "elasticsearch-mcp-server.chart" . }}
+{{ include "elasticsearch-mcp-server.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "elasticsearch-mcp-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "elasticsearch-mcp-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "elasticsearch-mcp-server.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "elasticsearch-mcp-server.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name of the Secret containing credentials.
+Returns the existing secret name if provided, otherwise the chart-managed secret name.
+*/}}
+{{- define "elasticsearch-mcp-server.secretName" -}}
+{{- if .Values.auth.existingSecret }}
+{{- .Values.auth.existingSecret }}
+{{- else }}
+{{- include "elasticsearch-mcp-server.fullname" . }}
+{{- end }}
+{{- end }}
+
+{{/*
+Resolve the MCP server URL path.
+Falls back to the transport-appropriate default when server.path is empty.
+*/}}
+{{- define "elasticsearch-mcp-server.serverPath" -}}
+{{- if .Values.server.path }}
+{{- .Values.server.path }}
+{{- else if eq .Values.server.transport "sse" }}
+{{- "/sse" }}
+{{- else }}
+{{- "/mcp" }}
+{{- end }}
+{{- end }}

--- a/helm/elasticsearch-mcp-server/templates/deployment.yaml
+++ b/helm/elasticsearch-mcp-server/templates/deployment.yaml
@@ -1,3 +1,6 @@
+{{- if eq .Values.server.transport "stdio" }}
+{{- fail "server.transport 'stdio' is not supported in Kubernetes. Use 'streamable-http' or 'sse'." }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/helm/elasticsearch-mcp-server/templates/deployment.yaml
+++ b/helm/elasticsearch-mcp-server/templates/deployment.yaml
@@ -1,0 +1,167 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "elasticsearch-mcp-server.fullname" . }}
+  labels:
+    {{- include "elasticsearch-mcp-server.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "elasticsearch-mcp-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        # Restart pods when the Secret content changes
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "elasticsearch-mcp-server.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "elasticsearch-mcp-server.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--transport"
+            - {{ .Values.server.transport | quote }}
+            - "--host"
+            - {{ .Values.server.host | quote }}
+            - "--port"
+            - {{ .Values.server.port | quote }}
+            - "--path"
+            - {{ include "elasticsearch-mcp-server.serverPath" . | quote }}
+          env:
+            - name: ENGINE_TYPE
+              value: {{ .Values.server.engineType | quote }}
+
+            {{- if eq .Values.server.engineType "opensearch" }}
+            # OpenSearch connection
+            - name: OPENSEARCH_HOSTS
+              value: {{ .Values.opensearch.hosts | quote }}
+            {{- if .Values.opensearch.username }}
+            - name: OPENSEARCH_USERNAME
+              value: {{ .Values.opensearch.username | quote }}
+            {{- end }}
+            - name: OPENSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "elasticsearch-mcp-server.secretName" . }}
+                  key: {{ .Values.auth.existingSecretKeys.elasticsearchPassword }}
+                  optional: true
+            - name: VERIFY_CERTS
+              value: {{ .Values.opensearch.verifyCerts | quote }}
+            {{- if .Values.opensearch.requestTimeout }}
+            - name: REQUEST_TIMEOUT
+              value: {{ .Values.opensearch.requestTimeout | quote }}
+            {{- end }}
+
+            {{- else }}
+            # Elasticsearch connection
+            - name: ELASTICSEARCH_HOSTS
+              value: {{ .Values.elasticsearch.hosts | quote }}
+            {{- if .Values.elasticsearch.username }}
+            - name: ELASTICSEARCH_USERNAME
+              value: {{ .Values.elasticsearch.username | quote }}
+            {{- end }}
+            - name: ELASTICSEARCH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "elasticsearch-mcp-server.secretName" . }}
+                  key: {{ .Values.auth.existingSecretKeys.elasticsearchPassword }}
+                  optional: true
+            - name: ELASTICSEARCH_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "elasticsearch-mcp-server.secretName" . }}
+                  key: {{ .Values.auth.existingSecretKeys.elasticsearchApiKey }}
+                  optional: true
+            - name: VERIFY_CERTS
+              value: {{ .Values.elasticsearch.verifyCerts | quote }}
+            {{- if .Values.elasticsearch.requestTimeout }}
+            - name: REQUEST_TIMEOUT
+              value: {{ .Values.elasticsearch.requestTimeout | quote }}
+            {{- end }}
+            {{- end }}
+
+            # MCP server Bearer token authentication
+            - name: MCP_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "elasticsearch-mcp-server.secretName" . }}
+                  key: {{ .Values.auth.existingSecretKeys.mcpApiKey }}
+                  optional: true
+
+            # Risk / write-operation control
+            - name: DISABLE_HIGH_RISK_OPERATIONS
+              value: {{ .Values.risk.disableHighRiskOperations | quote }}
+            {{- if .Values.risk.disabledOperations }}
+            - name: DISABLE_OPERATIONS
+              value: {{ .Values.risk.disabledOperations | quote }}
+            {{- end }}
+
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            - name: PYTHONDONTWRITEBYTECODE
+              value: "1"
+
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+          ports:
+            - name: http
+              containerPort: {{ .Values.server.port }}
+              protocol: TCP
+
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+          volumeMounts:
+            # Required when readOnlyRootFilesystem=true: Python needs /tmp for stdlib
+            - name: tmp
+              mountPath: /tmp
+            {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm/elasticsearch-mcp-server/templates/deployment.yaml
+++ b/helm/elasticsearch-mcp-server/templates/deployment.yaml
@@ -55,16 +55,22 @@ spec:
             # OpenSearch connection
             - name: OPENSEARCH_HOSTS
               value: {{ .Values.opensearch.hosts | quote }}
-            {{- if .Values.opensearch.username }}
+            {{- if or .Values.auth.existingSecret .Values.auth.credentials.opensearchUsername }}
             - name: OPENSEARCH_USERNAME
-              value: {{ .Values.opensearch.username | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "elasticsearch-mcp-server.secretName" . }}
+                  key: {{ .Values.auth.existingSecretKeys.opensearchUsername }}
+                  optional: true
             {{- end }}
+            {{- if or .Values.auth.existingSecret .Values.auth.credentials.opensearchPassword }}
             - name: OPENSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "elasticsearch-mcp-server.secretName" . }}
-                  key: {{ .Values.auth.existingSecretKeys.elasticsearchPassword }}
+                  key: {{ .Values.auth.existingSecretKeys.opensearchPassword }}
                   optional: true
+            {{- end }}
             - name: VERIFY_CERTS
               value: {{ .Values.opensearch.verifyCerts | quote }}
             {{- if .Values.opensearch.requestTimeout }}
@@ -76,22 +82,30 @@ spec:
             # Elasticsearch connection
             - name: ELASTICSEARCH_HOSTS
               value: {{ .Values.elasticsearch.hosts | quote }}
-            {{- if .Values.elasticsearch.username }}
+            {{- if or .Values.auth.existingSecret .Values.auth.credentials.elasticsearchUsername }}
             - name: ELASTICSEARCH_USERNAME
-              value: {{ .Values.elasticsearch.username | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "elasticsearch-mcp-server.secretName" . }}
+                  key: {{ .Values.auth.existingSecretKeys.elasticsearchUsername }}
+                  optional: true
             {{- end }}
+            {{- if or .Values.auth.existingSecret .Values.auth.credentials.elasticsearchPassword }}
             - name: ELASTICSEARCH_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ include "elasticsearch-mcp-server.secretName" . }}
                   key: {{ .Values.auth.existingSecretKeys.elasticsearchPassword }}
                   optional: true
+            {{- end }}
+            {{- if or .Values.auth.existingSecret .Values.auth.credentials.elasticsearchApiKey }}
             - name: ELASTICSEARCH_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "elasticsearch-mcp-server.secretName" . }}
                   key: {{ .Values.auth.existingSecretKeys.elasticsearchApiKey }}
                   optional: true
+            {{- end }}
             - name: VERIFY_CERTS
               value: {{ .Values.elasticsearch.verifyCerts | quote }}
             {{- if .Values.elasticsearch.requestTimeout }}
@@ -101,12 +115,14 @@ spec:
             {{- end }}
 
             # MCP server Bearer token authentication
+            {{- if or .Values.auth.existingSecret .Values.auth.credentials.mcpApiKey }}
             - name: MCP_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "elasticsearch-mcp-server.secretName" . }}
                   key: {{ .Values.auth.existingSecretKeys.mcpApiKey }}
                   optional: true
+            {{- end }}
 
             # Risk / write-operation control
             - name: DISABLE_HIGH_RISK_OPERATIONS

--- a/helm/elasticsearch-mcp-server/templates/hpa.yaml
+++ b/helm/elasticsearch-mcp-server/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "elasticsearch-mcp-server.fullname" . }}
+  labels:
+    {{- include "elasticsearch-mcp-server.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "elasticsearch-mcp-server.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/helm/elasticsearch-mcp-server/templates/ingress.yaml
+++ b/helm/elasticsearch-mcp-server/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "elasticsearch-mcp-server.fullname" . }}
+  labels:
+    {{- include "elasticsearch-mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- toYaml .Values.ingress.tls | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "elasticsearch-mcp-server.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/helm/elasticsearch-mcp-server/templates/secret.yaml
+++ b/helm/elasticsearch-mcp-server/templates/secret.yaml
@@ -1,0 +1,20 @@
+{{- if not .Values.auth.existingSecret }}
+{{- $anyCredential := or .Values.auth.credentials.elasticsearchPassword .Values.auth.credentials.elasticsearchApiKey .Values.auth.credentials.mcpApiKey }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "elasticsearch-mcp-server.fullname" . }}
+  labels:
+    {{- include "elasticsearch-mcp-server.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- if .Values.auth.credentials.elasticsearchPassword }}
+  {{ .Values.auth.existingSecretKeys.elasticsearchPassword }}: {{ .Values.auth.credentials.elasticsearchPassword | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.auth.credentials.elasticsearchApiKey }}
+  {{ .Values.auth.existingSecretKeys.elasticsearchApiKey }}: {{ .Values.auth.credentials.elasticsearchApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.auth.credentials.mcpApiKey }}
+  {{ .Values.auth.existingSecretKeys.mcpApiKey }}: {{ .Values.auth.credentials.mcpApiKey | b64enc | quote }}
+  {{- end }}
+{{- end }}

--- a/helm/elasticsearch-mcp-server/templates/secret.yaml
+++ b/helm/elasticsearch-mcp-server/templates/secret.yaml
@@ -1,5 +1,4 @@
 {{- if not .Values.auth.existingSecret }}
-{{- $anyCredential := or .Values.auth.credentials.elasticsearchPassword .Values.auth.credentials.elasticsearchApiKey .Values.auth.credentials.mcpApiKey }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,11 +7,20 @@ metadata:
     {{- include "elasticsearch-mcp-server.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if .Values.auth.credentials.elasticsearchUsername }}
+  {{ .Values.auth.existingSecretKeys.elasticsearchUsername }}: {{ .Values.auth.credentials.elasticsearchUsername | b64enc | quote }}
+  {{- end }}
   {{- if .Values.auth.credentials.elasticsearchPassword }}
   {{ .Values.auth.existingSecretKeys.elasticsearchPassword }}: {{ .Values.auth.credentials.elasticsearchPassword | b64enc | quote }}
   {{- end }}
   {{- if .Values.auth.credentials.elasticsearchApiKey }}
   {{ .Values.auth.existingSecretKeys.elasticsearchApiKey }}: {{ .Values.auth.credentials.elasticsearchApiKey | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.auth.credentials.opensearchUsername }}
+  {{ .Values.auth.existingSecretKeys.opensearchUsername }}: {{ .Values.auth.credentials.opensearchUsername | b64enc | quote }}
+  {{- end }}
+  {{- if .Values.auth.credentials.opensearchPassword }}
+  {{ .Values.auth.existingSecretKeys.opensearchPassword }}: {{ .Values.auth.credentials.opensearchPassword | b64enc | quote }}
   {{- end }}
   {{- if .Values.auth.credentials.mcpApiKey }}
   {{ .Values.auth.existingSecretKeys.mcpApiKey }}: {{ .Values.auth.credentials.mcpApiKey | b64enc | quote }}

--- a/helm/elasticsearch-mcp-server/templates/service.yaml
+++ b/helm/elasticsearch-mcp-server/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "elasticsearch-mcp-server.fullname" . }}
+  labels:
+    {{- include "elasticsearch-mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "elasticsearch-mcp-server.selectorLabels" . | nindent 4 }}

--- a/helm/elasticsearch-mcp-server/templates/serviceaccount.yaml
+++ b/helm/elasticsearch-mcp-server/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "elasticsearch-mcp-server.serviceAccountName" . }}
+  labels:
+    {{- include "elasticsearch-mcp-server.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/helm/elasticsearch-mcp-server/tests/deployment_credentials_test.yaml
+++ b/helm/elasticsearch-mcp-server/tests/deployment_credentials_test.yaml
@@ -1,0 +1,198 @@
+suite: "Deployment - credential env vars"
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+tests:
+
+  # ---------------------------------------------------------------------------
+  # No credentials set
+  # ---------------------------------------------------------------------------
+  - it: should not render any credential env vars when no credentials are set
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_USERNAME
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_PASSWORD
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_API_KEY
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_API_KEY
+          any: true
+
+  # ---------------------------------------------------------------------------
+  # Elasticsearch username + password
+  # ---------------------------------------------------------------------------
+  - it: should render ELASTICSEARCH_USERNAME and PASSWORD when set
+    set:
+      auth.credentials.elasticsearchUsername: admin
+      auth.credentials.elasticsearchPassword: secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: test-elasticsearch-mcp-server
+                key: elasticsearch-username
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-elasticsearch-mcp-server
+                key: elasticsearch-password
+                optional: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_API_KEY
+          any: true
+
+  # ---------------------------------------------------------------------------
+  # Elasticsearch API key (alternative to username/password)
+  # ---------------------------------------------------------------------------
+  - it: should render ELASTICSEARCH_API_KEY when set
+    set:
+      auth.credentials.elasticsearchApiKey: my-api-key
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-elasticsearch-mcp-server
+                key: elasticsearch-api-key
+                optional: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_USERNAME
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_PASSWORD
+          any: true
+
+  # ---------------------------------------------------------------------------
+  # OpenSearch username + password
+  # ---------------------------------------------------------------------------
+  - it: should render OPENSEARCH_USERNAME and PASSWORD when engineType is opensearch
+    set:
+      server.engineType: opensearch
+      auth.credentials.opensearchUsername: osadmin
+      auth.credentials.opensearchPassword: ossecret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPENSEARCH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: test-elasticsearch-mcp-server
+                key: opensearch-username
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPENSEARCH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: test-elasticsearch-mcp-server
+                key: opensearch-password
+                optional: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_USERNAME
+          any: true
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_PASSWORD
+          any: true
+
+  # ---------------------------------------------------------------------------
+  # existingSecret — all env vars must be rendered (contents are unknown)
+  # ---------------------------------------------------------------------------
+  - it: should render all ES credential env vars when existingSecret is set
+    set:
+      auth.existingSecret: my-external-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_USERNAME
+            valueFrom:
+              secretKeyRef:
+                name: my-external-secret
+                key: elasticsearch-username
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: my-external-secret
+                key: elasticsearch-password
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ELASTICSEARCH_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-external-secret
+                key: elasticsearch-api-key
+                optional: true
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: my-external-secret
+                key: mcp-api-key
+                optional: true
+
+  # ---------------------------------------------------------------------------
+  # MCP_API_KEY
+  # ---------------------------------------------------------------------------
+  - it: should render MCP_API_KEY when set
+    set:
+      auth.credentials.mcpApiKey: my-token
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: test-elasticsearch-mcp-server
+                key: mcp-api-key
+                optional: true
+
+  - it: should not render MCP_API_KEY when not set
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: MCP_API_KEY
+          any: true

--- a/helm/elasticsearch-mcp-server/tests/deployment_server_test.yaml
+++ b/helm/elasticsearch-mcp-server/tests/deployment_server_test.yaml
@@ -1,0 +1,105 @@
+suite: "Deployment - server configuration"
+templates:
+  - templates/deployment.yaml
+release:
+  name: test
+tests:
+
+  - it: should use streamable-http transport and /mcp path by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
+            - "--transport"
+            - "streamable-http"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "8000"
+            - "--path"
+            - "/mcp"
+
+  - it: should default path to /sse when transport is sse
+    set:
+      server.transport: sse
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "/sse"
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "/mcp"
+
+  - it: should use custom path when explicitly set
+    set:
+      server.path: /custom-mcp
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "/custom-mcp"
+
+  - it: should set ENGINE_TYPE to elasticsearch by default
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENGINE_TYPE
+            value: "elasticsearch"
+
+  - it: should set ENGINE_TYPE to opensearch when configured
+    set:
+      server.engineType: opensearch
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: ENGINE_TYPE
+            value: "opensearch"
+
+  - it: should configure liveness probe on /healthz
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /healthz
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: http
+
+  - it: should configure readiness probe on /readyz
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /readyz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: http
+
+  - it: should run as non-root with read-only root filesystem
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+
+  - it: should set replicas from replicaCount when autoscaling is disabled
+    set:
+      replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: should set DISABLE_HIGH_RISK_OPERATIONS env var
+    set:
+      risk.disableHighRiskOperations: "true"
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DISABLE_HIGH_RISK_OPERATIONS
+            value: "true"

--- a/helm/elasticsearch-mcp-server/tests/deployment_server_test.yaml
+++ b/helm/elasticsearch-mcp-server/tests/deployment_server_test.yaml
@@ -5,6 +5,13 @@ release:
   name: test
 tests:
 
+  - it: should fail rendering when transport is stdio
+    set:
+      server.transport: stdio
+    asserts:
+      - failedTemplate:
+          errorMessage: "server.transport 'stdio' is not supported in Kubernetes. Use 'streamable-http' or 'sse'."
+
   - it: should use streamable-http transport and /mcp path by default
     asserts:
       - equal:

--- a/helm/elasticsearch-mcp-server/tests/hpa_test.yaml
+++ b/helm/elasticsearch-mcp-server/tests/hpa_test.yaml
@@ -1,0 +1,43 @@
+suite: "HorizontalPodAutoscaler"
+templates:
+  - templates/hpa.yaml
+release:
+  name: test
+tests:
+
+  - it: should not create an HPA when autoscaling is disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create an HPA when autoscaling is enabled
+    set:
+      autoscaling.enabled: true
+      autoscaling.minReplicas: 2
+      autoscaling.maxReplicas: 10
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HorizontalPodAutoscaler
+      - equal:
+          path: spec.minReplicas
+          value: 2
+      - equal:
+          path: spec.maxReplicas
+          value: 10
+
+  - it: should include CPU metric when targetCPUUtilizationPercentage is set
+    set:
+      autoscaling.enabled: true
+      autoscaling.targetCPUUtilizationPercentage: 75
+    asserts:
+      - contains:
+          path: spec.metrics
+          content:
+            type: Resource
+            resource:
+              name: cpu
+              target:
+                type: Utilization
+                averageUtilization: 75

--- a/helm/elasticsearch-mcp-server/tests/ingress_test.yaml
+++ b/helm/elasticsearch-mcp-server/tests/ingress_test.yaml
@@ -1,0 +1,45 @@
+suite: "Ingress"
+templates:
+  - templates/ingress.yaml
+release:
+  name: test
+tests:
+
+  - it: should not create an Ingress when disabled
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should create an Ingress when enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+
+  - it: should set ingressClassName when specified
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: should set ingressClassName when specified
+    set:
+      ingress.enabled: true
+      ingress.className: nginx
+    asserts:
+      - equal:
+          path: spec.ingressClassName
+          value: nginx
+
+  - it: should render spec.rules when ingress is enabled
+    set:
+      ingress.enabled: true
+    asserts:
+      - isNotNullOrEmpty:
+          path: spec.rules

--- a/helm/elasticsearch-mcp-server/tests/ingress_test.yaml
+++ b/helm/elasticsearch-mcp-server/tests/ingress_test.yaml
@@ -28,13 +28,13 @@ tests:
           path: spec.ingressClassName
           value: nginx
 
-  - it: should set ingressClassName when specified
+  - it: should propagate annotations to the Ingress resource
     set:
       ingress.enabled: true
-      ingress.className: nginx
+      ingress.annotations.kubernetes\.io/ingress\.class: nginx
     asserts:
       - equal:
-          path: spec.ingressClassName
+          path: metadata.annotations["kubernetes.io/ingress.class"]
           value: nginx
 
   - it: should render spec.rules when ingress is enabled

--- a/helm/elasticsearch-mcp-server/tests/secret_test.yaml
+++ b/helm/elasticsearch-mcp-server/tests/secret_test.yaml
@@ -1,0 +1,74 @@
+suite: "Secret"
+templates:
+  - templates/secret.yaml
+release:
+  name: test
+tests:
+
+  - it: should create a Secret when no existingSecret is set
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Secret
+
+  - it: should not create a Secret when existingSecret is set
+    set:
+      auth.existingSecret: my-external-secret
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should encode elasticsearch credentials in Secret data
+    set:
+      auth.credentials.elasticsearchUsername: admin
+      auth.credentials.elasticsearchPassword: secret
+      auth.credentials.elasticsearchApiKey: my-api-key
+    asserts:
+      - equal:
+          path: data.elasticsearch-username
+          value: YWRtaW4=         # base64("admin")
+      - equal:
+          path: data.elasticsearch-password
+          value: c2VjcmV0         # base64("secret")
+      - equal:
+          path: data.elasticsearch-api-key
+          value: bXktYXBpLWtleQ== # base64("my-api-key")
+
+  - it: should encode opensearch credentials in Secret data
+    set:
+      auth.credentials.opensearchUsername: osadmin
+      auth.credentials.opensearchPassword: ossecret
+    asserts:
+      - equal:
+          path: data.opensearch-username
+          value: b3NhZG1pbg==  # base64("osadmin")
+      - equal:
+          path: data.opensearch-password
+          value: b3NzZWNyZXQ=  # base64("ossecret")
+
+  - it: should encode MCP API key in Secret data
+    set:
+      auth.credentials.mcpApiKey: my-mcp-token
+    asserts:
+      - equal:
+          path: data.mcp-api-key
+          value: bXktbWNwLXRva2Vu  # base64("my-mcp-token")
+
+  - it: should only include keys for explicitly set credentials
+    set:
+      auth.credentials.elasticsearchPassword: secret
+    asserts:
+      - equal:
+          path: data
+          value:
+            elasticsearch-password: c2VjcmV0
+
+  - it: should respect custom existingSecretKeys names
+    set:
+      auth.existingSecretKeys.elasticsearchPassword: es-pass
+      auth.credentials.elasticsearchPassword: secret
+    asserts:
+      - equal:
+          path: data.es-pass
+          value: c2VjcmV0

--- a/helm/elasticsearch-mcp-server/values.yaml
+++ b/helm/elasticsearch-mcp-server/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: elasticsearch-mcp-server
+  repository: ghcr.io/cr7258/elasticsearch-mcp-server
   pullPolicy: IfNotPresent
   # Defaults to .Chart.AppVersion when empty
   tag: ""

--- a/helm/elasticsearch-mcp-server/values.yaml
+++ b/helm/elasticsearch-mcp-server/values.yaml
@@ -1,0 +1,190 @@
+replicaCount: 1
+
+image:
+  repository: elasticsearch-mcp-server
+  pullPolicy: IfNotPresent
+  # Defaults to .Chart.AppVersion when empty
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  create: true
+  automount: false
+  annotations: {}
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+# ---------------------------------------------------------------------------
+# MCP server configuration
+# ---------------------------------------------------------------------------
+server:
+  # "elasticsearch" or "opensearch"
+  engineType: elasticsearch
+  # Transport protocol. Use streamable-http or sse for Kubernetes.
+  # stdio is for local process usage only.
+  transport: streamable-http
+  host: "0.0.0.0"
+  port: 8000
+  # URL path for the MCP endpoint.
+  # Defaults to /mcp (streamable-http) or /sse (sse) when left empty.
+  path: ""
+
+# ---------------------------------------------------------------------------
+# Elasticsearch connection settings (used when server.engineType=elasticsearch)
+# ---------------------------------------------------------------------------
+elasticsearch:
+  hosts: "https://elasticsearch:9200"
+  username: ""
+  verifyCerts: "false"
+  requestTimeout: ""
+
+# ---------------------------------------------------------------------------
+# OpenSearch connection settings (used when server.engineType=opensearch)
+# ---------------------------------------------------------------------------
+opensearch:
+  hosts: "https://opensearch:9200"
+  username: ""
+  verifyCerts: "false"
+  requestTimeout: ""
+
+# ---------------------------------------------------------------------------
+# Risk / write-operation control
+# ---------------------------------------------------------------------------
+risk:
+  # Set to "true" to disable ALL write/delete operations
+  disableHighRiskOperations: "false"
+  # Comma-separated list of specific operations to disable, e.g.:
+  # "delete_index,delete_document,delete_by_query"
+  disabledOperations: ""
+
+# ---------------------------------------------------------------------------
+# Secret management
+#
+# Option A — provide credentials here (chart creates a Secret):
+#   auth.credentials.elasticsearchPassword / elasticsearchApiKey / mcpApiKey
+#
+# Option B — point to an existing Secret (e.g. created by External Secrets):
+#   auth.existingSecret: my-secret-name
+#   auth.existingSecretKeys.*: key names inside that Secret
+# ---------------------------------------------------------------------------
+auth:
+  # Name of a pre-existing Secret. When set, no Secret is created by this chart.
+  existingSecret: ""
+  # Key names inside the Secret (applies to both chart-created and existing secrets)
+  existingSecretKeys:
+    elasticsearchPassword: "elasticsearch-password"
+    elasticsearchApiKey: "elasticsearch-api-key"
+    mcpApiKey: "mcp-api-key"
+  # Credentials — only used when existingSecret is empty
+  credentials:
+    elasticsearchPassword: ""
+    elasticsearchApiKey: ""
+    # MCP Bearer token. Required for HTTP transports in production.
+    mcpApiKey: ""
+
+# ---------------------------------------------------------------------------
+# Service
+# ---------------------------------------------------------------------------
+service:
+  type: ClusterIP
+  port: 8000
+  annotations: {}
+
+# ---------------------------------------------------------------------------
+# Ingress
+# ---------------------------------------------------------------------------
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    # nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+  hosts:
+    - host: elasticsearch-mcp-server.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  # - secretName: elasticsearch-mcp-server-tls
+  #   hosts:
+  #     - elasticsearch-mcp-server.local
+
+# ---------------------------------------------------------------------------
+# Resources
+# ---------------------------------------------------------------------------
+resources:
+  requests:
+    cpu: 100m
+    memory: 256Mi
+  limits:
+    cpu: 500m
+    memory: 512Mi
+
+# ---------------------------------------------------------------------------
+# Health probes
+# /healthz — liveness  (is the process alive?)
+# /readyz  — readiness (is the search engine reachable?)
+# ---------------------------------------------------------------------------
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /readyz
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 10
+  failureThreshold: 3
+
+# ---------------------------------------------------------------------------
+# Autoscaling
+# ---------------------------------------------------------------------------
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# ---------------------------------------------------------------------------
+# Extra configuration
+# ---------------------------------------------------------------------------
+# Additional environment variables injected into the container
+extraEnv: []
+# - name: EXTRA_VAR
+#   value: "value"
+
+# Extra volumes and mounts (e.g. for custom CA certificates)
+volumes: []
+volumeMounts: []
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/helm/elasticsearch-mcp-server/values.yaml
+++ b/helm/elasticsearch-mcp-server/values.yaml
@@ -54,7 +54,6 @@ server:
 # ---------------------------------------------------------------------------
 elasticsearch:
   hosts: "https://elasticsearch:9200"
-  username: ""
   verifyCerts: "false"
   requestTimeout: ""
 
@@ -63,7 +62,6 @@ elasticsearch:
 # ---------------------------------------------------------------------------
 opensearch:
   hosts: "https://opensearch:9200"
-  username: ""
   verifyCerts: "false"
   requestTimeout: ""
 
@@ -81,24 +79,33 @@ risk:
 # Secret management
 #
 # Option A — provide credentials here (chart creates a Secret):
-#   auth.credentials.elasticsearchPassword / elasticsearchApiKey / mcpApiKey
+#   Set the relevant fields under auth.credentials and leave auth.existingSecret empty.
 #
-# Option B — point to an existing Secret (e.g. created by External Secrets):
+# Option B — point to an existing Secret (e.g. created by External Secrets Operator):
 #   auth.existingSecret: my-secret-name
-#   auth.existingSecretKeys.*: key names inside that Secret
+#   Optionally override auth.existingSecretKeys.* if your key names differ.
 # ---------------------------------------------------------------------------
 auth:
   # Name of a pre-existing Secret. When set, no Secret is created by this chart.
   existingSecret: ""
   # Key names inside the Secret (applies to both chart-created and existing secrets)
   existingSecretKeys:
+    elasticsearchUsername: "elasticsearch-username"
     elasticsearchPassword: "elasticsearch-password"
     elasticsearchApiKey: "elasticsearch-api-key"
+    opensearchUsername: "opensearch-username"
+    opensearchPassword: "opensearch-password"
     mcpApiKey: "mcp-api-key"
-  # Credentials — only used when existingSecret is empty
+  # Credentials — only used when existingSecret is empty.
+  # Populate only the fields relevant to your engine type and auth method.
   credentials:
+    # Elasticsearch: username/password or API key (API key takes precedence)
+    elasticsearchUsername: ""
     elasticsearchPassword: ""
     elasticsearchApiKey: ""
+    # OpenSearch: username/password
+    opensearchUsername: ""
+    opensearchPassword: ""
     # MCP Bearer token. Required for HTTP transports in production.
     mcpApiKey: ""
 

--- a/src/server.py
+++ b/src/server.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import os
 import sys
@@ -5,6 +6,8 @@ import argparse
 
 from fastmcp import FastMCP
 from fastmcp.server.auth import StaticTokenVerifier
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
 
 from src.clients import create_search_client
 from src.tools.alias import AliasTools
@@ -60,6 +63,7 @@ class SearchMCPServer:
 
         # Initialize tools
         self._register_tools()
+        self._register_health_routes()
 
     def _create_fastmcp_auth(self, api_key: str):
         """Create FastMCP built-in authentication provider.
@@ -79,6 +83,34 @@ class SearchMCPServer:
             }
         }
         return StaticTokenVerifier(tokens=tokens)
+
+    def _register_health_routes(self):
+        """Register /healthz (liveness) and /readyz (readiness) HTTP endpoints.
+
+        These are only served when running with an HTTP transport (sse or
+        streamable-http) and are designed for Kubernetes probes.
+        """
+
+        @self.mcp.custom_route("/healthz", methods=["GET"], include_in_schema=False)
+        async def liveness(request: Request) -> Response:
+            return JSONResponse({"status": "ok"})
+
+        @self.mcp.custom_route("/readyz", methods=["GET"], include_in_schema=False)
+        async def readiness(request: Request) -> Response:
+            try:
+                reachable = await asyncio.to_thread(self.search_client.client.ping)
+            except Exception as exc:
+                self.logger.warning("Readiness check failed: %s", exc)
+                return JSONResponse(
+                    {"status": "error", "search_engine": self.engine_type, "detail": str(exc)},
+                    status_code=503,
+                )
+            if reachable:
+                return JSONResponse({"status": "ok", "search_engine": self.engine_type})
+            return JSONResponse(
+                {"status": "unavailable", "search_engine": self.engine_type},
+                status_code=503,
+            )
 
     def _register_tools(self):
         """Register all MCP tools."""

--- a/src/server.py
+++ b/src/server.py
@@ -98,11 +98,20 @@ class SearchMCPServer:
         @self.mcp.custom_route("/readyz", methods=["GET"], include_in_schema=False)
         async def readiness(request: Request) -> Response:
             try:
-                reachable = await asyncio.to_thread(self.search_client.client.ping)
+                reachable = await asyncio.wait_for(
+                    asyncio.to_thread(self.search_client.client.ping),
+                    timeout=5.0,
+                )
+            except asyncio.TimeoutError:
+                self.logger.warning("Readiness check timed out")
+                return JSONResponse(
+                    {"status": "timeout", "search_engine": self.engine_type},
+                    status_code=503,
+                )
             except Exception as exc:
                 self.logger.warning("Readiness check failed: %s", exc)
                 return JSONResponse(
-                    {"status": "error", "search_engine": self.engine_type, "detail": str(exc)},
+                    {"status": "error", "search_engine": self.engine_type},
                     status_code=503,
                 )
             if reachable:


### PR DESCRIPTION
This proposal adds Kubernetes support for the MCP server by providing a production-ready Docker image and a Helm chart.

### Docker
- Multi-stage build using ghcr.io/astral-sh/uv:python3.10-bookworm-slim as builder and python:3.10-slim-bookworm as runtime — uv is not present in the final image
- Dependencies are installed with uv sync --frozen --no-editable and bytecode-compiled at build time for fast startup
- Runs as a non-root user (UID 1000) with a read-only root filesystem and ALL capabilities dropped
- `docker/entrypoint.sh` selects the entry point (elasticsearch-mcp-server or opensearch-mcp-server) based on the ENGINE_TYPE env var, defaulting to elasticsearch
- Container defaults to streamable-http transport on 0.0.0.0:8000, which is the correct transport for HTTP-based deployments
### Health endpoints
Two new HTTP endpoints are registered via FastMCP's custom_route on the MCP server instance:
- GET /healthz — liveness: returns 200 {"status": "ok"} immediately; only checks that the process is alive
- GET /readyz — readiness: pings the configured Elasticsearch/OpenSearch cluster via asyncio.to_thread; returns 503 if the cluster is unreachable or returns a non-success response.

These endpoints are excluded from the OpenAPI schema and are only active when using an HTTP transport (streamable-http or sse).

### Helm chart (helm/elasticsearch-mcp-server/)
A full-featured Helm chart with:

- Configurable engine type (elasticsearch or opensearch) and transport protocol
- Two secret strategies: provide credentials directly in values (chart creates a Secret), or reference an existing one via auth.existingSecret (compatible with External Secrets Operator and similar tools)
- All sensitive values (ELASTICSEARCH_PASSWORD, ELASTICSEARCH_API_KEY, MCP_API_KEY) are mounted from a Secret with optional: true so missing keys don't crash the pod
- `checksum/secret` pod annotation forces a rollout when credentials change
- Liveness probe on `/healthz` and readiness probe on `/readyz`
- Optional Ingress, HPA, and ServiceAccount
- Pod security hardening: runAsNonRoot, readOnlyRootFilesystem, dropped capabilities, seccomp RuntimeDefault
/tmp emptyDir volume to satisfy Python's stdlib when readOnlyRootFilesystem=true
- Helm chart includes tests based on `helm unitest` plugin.


### NOTES
1. I've tested this in my own kubernetes cluster 
2. I can take care of creating a GitHub Actions workflow to run `helm unitests` whenever there are changes in 
In case this proposal is not
3. It would be amazing to build and push the docker image to GH Registry. We could do a similar approach for the chart. We could follow a similar approach as in https://github.com/pab1it0/prometheus-mcp-server
4. In case you prefer to keep all this out of this repository we could create a different repository.