### PR TITLE
fix: warn when unauthenticated server listens on all interfaces

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -157,7 +157,11 @@ def run_search_server(engine_type, transport, host, port, path):
         api_key = os.environ.get("MCP_API_KEY")
         if not api_key:
             logging.warning(
-                "MCP_API_KEY not set. Server will be accessible without authentication!"
+                "Server is listening on %s:%s without authentication. "
+                "We recommend setting the MCP_API_KEY "
+                "environment variable to enable Bearer token authentication.",
+                host,
+                port,
             )
 
     server = SearchMCPServer(engine_type=engine_type, api_key=api_key)

--- a/tests/unit/server/test_search_mcp_server.py
+++ b/tests/unit/server/test_search_mcp_server.py
@@ -48,10 +48,15 @@ def test_search_mcp_server_creates_static_token_verifier_when_api_key_is_provide
     }
 
 
-def test_search_mcp_server_disables_auth_when_no_api_key(stub_dependencies):
+def test_search_mcp_server_warns_when_no_api_key(stub_dependencies, caplog):
     server = SearchMCPServer(engine_type="elasticsearch", api_key=None)
 
     assert server.mcp.auth is None
+    assert caplog.messages == [
+        "MCP_API_KEY not set - authentication is DISABLED. Anyone can access this "
+        "MCP server without authentication. Set MCP_API_KEY environment variable "
+        "to enable authentication."
+    ]
 
 
 def test_search_mcp_server_uses_search_client_manager_from_factory(stub_dependencies):

--- a/tests/unit/server/test_server.py
+++ b/tests/unit/server/test_server.py
@@ -1,4 +1,5 @@
 import sys
+from unittest.mock import Mock
 
 import pytest
 
@@ -81,6 +82,24 @@ def test_run_search_server_passes_mcp_api_key_for_http_transport(monkeypatch):
                 "path": "/mcp",
             },
         }
+    ]
+
+
+@pytest.mark.parametrize("host", ["0.0.0.0", "127.0.0.1"])
+def test_run_search_server_warns_for_unauthenticated_http_transport(
+    monkeypatch, caplog, host
+):
+    fake_server = Mock()
+    fake_server.name = "fake-server"
+    monkeypatch.delenv("MCP_API_KEY", raising=False)
+    monkeypatch.setattr(server, "SearchMCPServer", Mock(return_value=fake_server))
+
+    server.run_search_server("elasticsearch", "streamable-http", host, 8000, "/mcp")
+
+    assert caplog.messages == [
+        f"Server is listening on {host}:8000 without authentication. "
+        "We recommend setting the MCP_API_KEY "
+        "environment variable to enable Bearer token authentication."
     ]
 
 


### PR DESCRIPTION
## Summary

- include the listening address in the warning emitted when an HTTP transport starts without `MCP_API_KEY`
- recommend setting `MCP_API_KEY` to enable Bearer token authentication
- add unit coverage for both all-interface and loopback bindings

## Impact

Runtime behavior and authentication requirements are unchanged.

## Validation

- `uv run --locked pytest -m unit` (105 passed)

Closes #70
